### PR TITLE
Add HttpClientModule to enable API calls

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
 import { AppComponent } from './app.component';
 import { PlantListComponent } from './plant-list/plant-list.component';
 import { PlantDetailComponent } from './plant-detail/plant-detail.component';
@@ -13,6 +14,7 @@ import { AppRoutingModule } from './app-routing.module';
   ],
   imports: [
     BrowserModule,
+    HttpClientModule,
     AppRoutingModule
   ],
   providers: [],


### PR DESCRIPTION
Hi Emily,

I reviewed your houseplants project and found the issue. The problem wasn't with the routing configuration itself, but rather with missing HTTP functionality. Your components weren't rendering because they depend on data from the PlantService, which uses HTTP calls to fetch data from your backend.

I've created a pull request with the fix - adding HttpClientModule to the imports array in app.module.ts. This module is required for making HTTP requests in Angular, and without it, your service calls weren't able to connect to your backend server. That's why you could only see the static h1 tag from app.component.html, but none of the dynamic content was loading.

Once you merge this PR, try running ng serve again and you should see your plant list and detail views working properly. Let me know if you need anything else!

Best,
Brother Del Sol